### PR TITLE
Enable riscv64 platform support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,14 @@ jobs:
         include:
           - base: core
             arch: armhf
-            runner: ubuntu-20.04
+            runner: ["self-hosted", "focal"]
           - base: core
             arch: arm64
-            runner: ubuntu-20.04
+            runner: ["self-hosted", "focal"]
           - base: core
             arch: amd64
-            runner: ubuntu-20.04
-          - base: core24
+            runner: ["self-hosted", "focal"]
+          - base: core22
             arch: riscv64
             runner: ubuntu-latest
           - base: core24

--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -15,15 +15,7 @@ afterEach(() => {
 })
 
 test('SnapcraftBuilder expands tilde in project root', () => {
-  let builder = new build.SnapcraftBuilder(
-    '~',
-    true,
-    'stable',
-    '',
-    '',
-    [],
-    ''
-  )
+  let builder = new build.SnapcraftBuilder('~', true, 'stable', '', '', [], '')
   expect(builder.projectRoot).toBe(os.homedir())
 
   builder = new build.SnapcraftBuilder(

--- a/dist/index.js
+++ b/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n
-        Error Code : ${error.statusCode}\n
+                throw new Error(`Failed to get ID Token. \n 
+        Error Code : ${error.statusCode}\n 
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -4038,7 +4038,7 @@ module.exports = require("util");
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/
+/******/ 	
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -4052,7 +4052,7 @@ module.exports = require("util");
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/
+/******/ 	
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -4061,11 +4061,11 @@ module.exports = require("util");
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/
+/******/ 	
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/
+/******/ 	
 /************************************************************************/
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
@@ -4077,11 +4077,11 @@ module.exports = require("util");
 /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
 /******/ 		};
 /******/ 	})();
-/******/
+/******/ 	
 /******/ 	/* webpack/runtime/compat */
-/******/
+/******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/
+/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
@@ -8163,10 +8163,9 @@ class SnapcraftBuilder {
         if (this.architecture in platforms) {
             dockerArgs = dockerArgs.concat('--platform', platforms[this.architecture]);
             pullArgs = pullArgs.concat('--platform', platforms[this.architecture]);
-        }else{
-          throw new Error(
-            'Architecture is wrong or unsupported by this action'
-          )
+        }
+        else if (this.architecture) {
+            throw new Error('Architecture is wrong or unsupported by this action');
         }
         for (const key in env) {
             dockerArgs = dockerArgs.concat('--env', `${key}=${env[key]}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8115,7 +8115,8 @@ const platforms = {
     armhf: 'linux/arm/v7',
     arm64: 'linux/arm64',
     ppc64el: 'linux/ppc64le',
-    s390x: 'linux/s390x'
+    s390x: 'linux/s390x',
+    riscv64: 'linux/riscv64'
 };
 class SnapcraftBuilder {
     constructor(projectRoot, includeBuildInfo, snapcraftChannel, snapcraftArgs, architecture, environment, storeAuth) {
@@ -8162,6 +8163,10 @@ class SnapcraftBuilder {
         if (this.architecture in platforms) {
             dockerArgs = dockerArgs.concat('--platform', platforms[this.architecture]);
             pullArgs = pullArgs.concat('--platform', platforms[this.architecture]);
+        }else{
+          throw new Error(
+            'Architecture is wrong or unsupported by this action'
+          )
         }
         for (const key in env) {
             dockerArgs = dockerArgs.concat('--env', `${key}=${env[key]}`);

--- a/src/build.ts
+++ b/src/build.ts
@@ -32,7 +32,8 @@ export const platforms: {[key: string]: string} = {
   armhf: 'linux/arm/v7',
   arm64: 'linux/arm64',
   ppc64el: 'linux/ppc64le',
-  s390x: 'linux/s390x'
+  s390x: 'linux/s390x',
+  riscv64: 'linux/riscv64'
 }
 
 export class SnapcraftBuilder {
@@ -106,6 +107,10 @@ export class SnapcraftBuilder {
     if (this.architecture in platforms) {
       dockerArgs = dockerArgs.concat('--platform', platforms[this.architecture])
       pullArgs = pullArgs.concat('--platform', platforms[this.architecture])
+    }else{
+      throw new Error(
+        'Architecture is wrong or unsupported by this action'
+      )
     }
 
     for (const key in env) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -107,10 +107,8 @@ export class SnapcraftBuilder {
     if (this.architecture in platforms) {
       dockerArgs = dockerArgs.concat('--platform', platforms[this.architecture])
       pullArgs = pullArgs.concat('--platform', platforms[this.architecture])
-    }else{
-      throw new Error(
-        'Architecture is wrong or unsupported by this action'
-      )
+    } else if (this.architecture) {
+      throw new Error('Architecture is wrong or unsupported by this action')
     }
 
     for (const key in env) {


### PR DESCRIPTION
Although I thought that the previous commit was enough to get this going, it seems that there was no validation of the parameter and, in order to make this work, an additional modification was needed.

This adds the riscv platform to the action. Also, this adds a check to validate platform failing the execution if it is not found to not let issues like this sneek by