### PR TITLE
Always set channel if only risk is declared

### DIFF
--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -49,8 +49,11 @@ for (const base of ['core', 'core18', 'core20', 'core22', 'core24']) {
       case 'core18':
         channel = '5.x/stable'
         break
+      case 'core20':
+        channel = '8.x/stable'
+        break
       default:
-        channel = 'stable'
+        channel = '9.x/stable'
     }
     matrix.push([base, arch, channel])
   }
@@ -179,7 +182,7 @@ test('SnapcraftBuilder.build can disable build info', async () => {
       '--env',
       `SNAPCRAFT_IMAGE_INFO={"build_url":"https://github.com/user/repo/actions/runs/42"}`,
       '--env',
-      'USE_SNAPCRAFT_CHANNEL=stable',
+      'USE_SNAPCRAFT_CHANNEL=9.x/stable',
       `ghcr.io/canonical/snapcraft-container:${default_base}`,
       'snapcraft'
     ],
@@ -231,7 +234,7 @@ test('SnapcraftBuilder.build can pass additional arguments', async () => {
       '--env',
       `SNAPCRAFT_IMAGE_INFO={"build_url":"https://github.com/user/repo/actions/runs/42"}`,
       '--env',
-      'USE_SNAPCRAFT_CHANNEL=stable',
+      'USE_SNAPCRAFT_CHANNEL=9.x/stable',
       `ghcr.io/canonical/snapcraft-container:${default_base}`,
       'snapcraft',
       '--foo',
@@ -287,7 +290,7 @@ test('SnapcraftBuilder.build can pass extra environment variables', async () => 
       '--env',
       `SNAPCRAFT_IMAGE_INFO={"build_url":"https://github.com/user/repo/actions/runs/42"}`,
       '--env',
-      'USE_SNAPCRAFT_CHANNEL=stable',
+      'USE_SNAPCRAFT_CHANNEL=9.x/stable',
       `ghcr.io/canonical/snapcraft-container:${default_base}`,
       'snapcraft',
       '--foo',
@@ -339,7 +342,7 @@ test('SnapcraftBuilder.build adds store credentials', async () => {
       '--env',
       `SNAPCRAFT_IMAGE_INFO={"build_url":"https://github.com/user/repo/actions/runs/42"}`,
       '--env',
-      'USE_SNAPCRAFT_CHANNEL=stable',
+      'USE_SNAPCRAFT_CHANNEL=9.x/stable',
       '--env',
       'SNAPCRAFT_STORE_CREDENTIALS=TEST_STORE_CREDENTIALS',
       `ghcr.io/canonical/snapcraft-container:${default_base}`,

--- a/__tests__/channel-matrix.test.ts
+++ b/__tests__/channel-matrix.test.ts
@@ -21,10 +21,10 @@ for (const [base, channel, expected] of [
   ['core18', '5.x/candidate', '5.x/candidate'],
   ['core18', '5.x/beta', '5.x/beta'],
   ['core18', '5.x/edge', '5.x/edge'],
-  ['core20', 'stable', 'stable'],
-  ['core20', 'candidate', 'candidate'],
-  ['core20', 'beta', 'beta'],
-  ['core20', 'edge', 'edge'],
+  ['core20', 'stable', '8.x/stable'],
+  ['core20', 'candidate', '8.x/candidate'],
+  ['core20', 'beta', '8.x/beta'],
+  ['core20', 'edge', '8.x/edge'],
   ['core20', '4.x/stable', '4.x/stable'],
   ['core20', '4.x/candidate', '4.x/candidate'],
   ['core20', '4.x/beta', '4.x/beta'],
@@ -40,14 +40,14 @@ for (const [base, channel, expected] of [
   })
 }
 
-for (const [base, channel] of [
-  ['core', '5.x/stable'],
-  ['core', '5.x/candidate'],
-  ['core', '5.x/beta'],
-  ['core', '5.x/edge']
+for (const [base, channel, expected] of [
+  ['core', '5.x/stable', '5.x/stable'],
+  ['core', '5.x/candidate', '5.x/candidate'],
+  ['core', '5.x/beta', '5.x/beta'],
+  ['core', '5.x/edge', '5.x/edge']
 ]) {
-  test(`getChannel for '${base}' and '${channel}' throws an error`, () => {
+  test(`getChannel for '${base}' and '${channel}' returns '${expected}'`, () => {
     expect.assertions(1)
-    expect(() => getChannel(base, channel)).toThrow()
+    expect(getChannel(base, channel)).toEqual(expected)
   })
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8065,28 +8065,26 @@ function parseArgs(argumentsString) {
 }
 
 ;// CONCATENATED MODULE: ./lib/channel-matrix.js
+function preferredChannel(base_channele, channel) {
+    if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
+        return `${base_channele}/${channel}`;
+    }
+    return channel;
+}
 function getChannel(base, channel) {
     switch (base) {
         case 'core24':
+            return preferredChannel('9.x', channel);
         case 'core22':
+            return preferredChannel('9.x', channel);
         case 'core20':
-            return channel;
+            return preferredChannel('8.x', channel);
         case 'core18':
-            if (channel.startsWith('5.x/')) {
-                return channel;
-            }
-            if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
-                return `5.x/${channel}`;
-            }
+            return preferredChannel('5.x', channel);
         case 'core':
-            if (channel.startsWith('4.x/')) {
-                return channel;
-            }
-            if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
-                return `4.x/${channel}`;
-            }
+            return preferredChannel('4.x', channel);
     }
-    throw new Error(`Snapcraft Channel '${channel}' is unsupported for builds targetting the '${base}' Base Snap.`);
+    return channel;
 }
 
 ;// CONCATENATED MODULE: ./lib/build.js

--- a/src/channel-matrix.ts
+++ b/src/channel-matrix.ts
@@ -1,26 +1,22 @@
+function preferredChannel(base_channele: string, channel: string): string {
+  if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
+    return `${base_channele}/${channel}`
+  }
+  return channel
+}
+
 export function getChannel(base: string, channel: string): string {
   switch (base) {
     case 'core24':
+      return preferredChannel('9.x', channel)
     case 'core22':
+      return preferredChannel('9.x', channel)
     case 'core20':
-      return channel
+      return preferredChannel('8.x', channel)
     case 'core18':
-      if (channel.startsWith('5.x/')) {
-        return channel
-      }
-      if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
-        return `5.x/${channel}`
-      }
+      return preferredChannel('5.x', channel)
     case 'core':
-      if (channel.startsWith('4.x/')) {
-        return channel
-      }
-      if (['stable', 'candidate', 'beta', 'edge'].includes(channel)) {
-        return `4.x/${channel}`
-      }
+      return preferredChannel('4.x', channel)
   }
-
-  throw new Error(
-    `Snapcraft Channel '${channel}' is unsupported for builds targetting the '${base}' Base Snap.`
-  )
+  return channel
 }


### PR DESCRIPTION
This shouldn't validate the channel, as that is non-trivial and done by snapcraft. The user knows best here, lets give them the service: setting the channel if they give us a risk and call it a day.
This also fixes the snapcraft version per release, this is done because the every two years pipelines go red due to the new snapcraft (latest) not supporting an older base requring an immidiate action. This fixes it.